### PR TITLE
Fix support for vendoring and add installation instructions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,0 +1,13 @@
+# Prototype Legacy Helper
+
+This plugin adds support for `form_remote_tag`, etc from Rails 2 to Rails 3.
+
+## Installation
+
+Either add the following to your `Gemfile` and run `bundle`:
+
+    gem 'prototype_legacy_helper', '0.0.0', :git => 'git://github.com/rails/prototype_legacy_helper.git'
+
+or run the following command to vendor the plugin within your app:
+
+    rails plugin install git://github.com/rails/prototype_legacy_helper.git

--- a/init.rb
+++ b/init.rb
@@ -1,0 +1,1 @@
+require 'prototype_legacy_helper'


### PR DESCRIPTION
I had somebody email me asking for help with installing this plugin. They were close but had a small but significant errors in their command. The attached README contains working installation instructions.
